### PR TITLE
Replace "launchpad.net/go-check" to "gopkg.in/check.v1"

### DIFF
--- a/gat/suite_test.go
+++ b/gat/suite_test.go
@@ -1,7 +1,7 @@
 package gat_test
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 	"testing"
 )
 

--- a/input_test.go
+++ b/input_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *LooperSuite) TestMixedCaseCommand(c *C) {

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 	"testing"
 )
 


### PR DESCRIPTION
Hi!

I tried `go test` in this project, but the error was caused because go-check is missing.
("launchpad.net/gocheck" has renamed to "gopkg.in/check.v1")

And please see this: [http://gocover.io/github.com/aibou/looper](http://gocover.io/github.com/aibou/looper)
