### PR TITLE
Add ability to pass arbitrary arguments to `go test`

### DIFF
--- a/gat/run.go
+++ b/gat/run.go
@@ -9,6 +9,9 @@ import (
 
 type Run struct {
 	Tags string
+
+	// Additional args to pass to `go test`
+	Args []string
 }
 
 func (run Run) RunAll() {
@@ -28,6 +31,11 @@ func (run Run) goTest(test_files string) {
 	if len(run.Tags) > 0 {
 		args = append(args, []string{"-tags", run.Tags}...)
 	}
+
+	for _, arg := range run.Args {
+		args = append(args, arg)
+	}
+
 	args = append(args, test_files)
 
 	command := "go"

--- a/gat/run.go
+++ b/gat/run.go
@@ -8,8 +8,6 @@ import (
 )
 
 type Run struct {
-	Tags string
-
 	// Additional args to pass to `go test`
 	Args []string
 }
@@ -27,17 +25,7 @@ func (run Run) RunOnChange(file string) {
 }
 
 func (run Run) goTest(test_files string) {
-	args := []string{"test"}
-	if len(run.Tags) > 0 {
-		args = append(args, []string{"-tags", run.Tags}...)
-	}
-
-	for _, arg := range run.Args {
-		args = append(args, arg)
-	}
-
-	args = append(args, test_files)
-
+	args := run.buildCmdArgs(test_files)
 	command := "go"
 
 	if _, err := os.Stat("Godeps/Godeps.json"); err == nil {
@@ -62,4 +50,18 @@ func (run Run) goTest(test_files string) {
 
 func isGoFile(file string) bool {
 	return filepath.Ext(file) == ".go"
+}
+
+func (run Run) buildCmdArgs(test_files string) []string {
+	// go test command: test
+	args := []string{"test"}
+
+	// additional args passed in on looper cmd line
+	for _, arg := range run.Args {
+		args = append(args, arg)
+	}
+
+	args = append(args, test_files)
+
+	return args
 }

--- a/gat/run.go
+++ b/gat/run.go
@@ -53,15 +53,27 @@ func isGoFile(file string) bool {
 }
 
 func (run Run) buildCmdArgs(test_files string) []string {
+	var haveAddedFiles bool
+
 	// go test command: test
 	args := []string{"test"}
 
 	// additional args passed in on looper cmd line
+	// if the arg is {} then the files will be places there
+	// if {} is not specifed then they will be appened
+	// to the end of the go test call
 	for _, arg := range run.Args {
-		args = append(args, arg)
+		if arg == "{}" {
+			args = append(args, test_files)
+			haveAddedFiles = true
+		} else {
+			args = append(args, arg)
+		}
 	}
 
-	args = append(args, test_files)
+	if !haveAddedFiles {
+		args = append(args, test_files)
+	}
 
 	return args
 }

--- a/looper.go
+++ b/looper.go
@@ -2,10 +2,9 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/nathany/looper/gat"
 )
@@ -45,22 +44,14 @@ out:
 }
 
 func main() {
-	var tags string
-	var debug bool
-	flag.StringVar(&tags, "tags", "", "a list of build tags for testing.")
-	flag.BoolVar(&debug, "debug", false, "adds additional logging")
-	flag.Usage = func() {
-		fmt.Printf("Usage: %s [options] [-- [go test options]]\n", os.Args[0])
-		flag.PrintDefaults()
-		fmt.Println(`
-  EXAMPLE: Specify a -run option to go test, run looper in debug mode:
-      looper -debug -- -run MyTest`)
-	}
-	flag.Parse()
+	// Get debug status from env var, if error ignore and debug is off
+	debug, _ := strconv.ParseBool(os.Getenv("LOOPER_DEBUG"))
 
-	runner := gat.Run{Tags: tags, Args: flag.Args()}
+	// Pass all args to go test, except the name of the looper command
+	gtargs := os.Args[1:len(os.Args)]
+	runner := gat.Run{Args: gtargs}
 
-	Header()
+	Header(gtargs)
 	if debug {
 		DebugEnabled()
 	}

--- a/looper.go
+++ b/looper.go
@@ -3,7 +3,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/nathany/looper/gat"
 )
@@ -47,9 +49,16 @@ func main() {
 	var debug bool
 	flag.StringVar(&tags, "tags", "", "a list of build tags for testing.")
 	flag.BoolVar(&debug, "debug", false, "adds additional logging")
+	flag.Usage = func() {
+		fmt.Printf("Usage: %s [options] [-- [go test options]]\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Println(`
+  EXAMPLE: Specify a -run option to go test, run looper in debug mode:
+      looper -debug -- -run MyTest`)
+	}
 	flag.Parse()
 
-	runner := gat.Run{Tags: tags}
+	runner := gat.Run{Tags: tags, Args: flag.Args()}
 
 	Header()
 	if debug {

--- a/print.go
+++ b/print.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/koyachi/go-term-ansicolor/ansicolor"
@@ -8,6 +9,15 @@ import (
 
 func Header() {
 	fmt.Println(ansicolor.Cyan("Looper 0.3.2 is watching your files"))
+
+	testArgLen := len(flag.Args())
+	if testArgLen > 0 {
+		fmt.Printf(ansicolor.Green("Passing %d addition argument(s) to go test:\n"), testArgLen)
+		for _, arg := range flag.Args() {
+			fmt.Printf(ansicolor.Green("  %s\n"), arg)
+		}
+	}
+
 	fmt.Println("Type " + ansicolor.Magenta("help") + " for help.\n")
 }
 

--- a/print.go
+++ b/print.go
@@ -1,21 +1,20 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/koyachi/go-term-ansicolor/ansicolor"
 )
 
-func Header() {
-	fmt.Println(ansicolor.Cyan("Looper 0.3.2 is watching your files"))
+func Header(gtargs []string) {
+	fmt.Println(ansicolor.Cyan("Looper 0.3.4 is watching your files"))
 
-	testArgLen := len(flag.Args())
-	if testArgLen > 0 {
-		fmt.Printf(ansicolor.Green("Passing %d addition argument(s) to go test:\n"), testArgLen)
-		for _, arg := range flag.Args() {
+	if len(gtargs) > 0 {
+		fmt.Printf(ansicolor.Green("Passing %d addition argument(s) to go test:\n"), len(gtargs))
+		for _, arg := range gtargs {
 			fmt.Printf(ansicolor.Green("  %s\n"), arg)
 		}
+		fmt.Println(ansicolor.Green("  <files>"))
 	}
 
 	fmt.Println("Type " + ansicolor.Magenta("help") + " for help.\n")


### PR DESCRIPTION
Add ability to pass arbitrary arguments to `go test`.  

As to not interfere with the current `looper` options you must prefix any `go test` options with the double hyphen (`--`), ala:

```
looper -debug -- -run MyTest
```

This really renders the `-tags` flag obsolete as it has the same format in `go test`; however removing it would be a breaking change for others.
