### PR TITLE
Adding support for testing with appengine classic

### DIFF
--- a/gat/run.go
+++ b/gat/run.go
@@ -12,7 +12,8 @@ import (
 var IgnoreVendor = (os.Getenv("GO15VENDOREXPERIMENT") == "1")
 
 type Run struct {
-	Tags string
+	Tags    string
+	Command string
 }
 
 func (run Run) RunAll() {
@@ -39,7 +40,7 @@ func (run Run) goTest(pkgs ...string) {
 	}
 	args = append(args, pkgs...)
 
-	command := "go"
+	command := run.Command
 
 	if _, err := os.Stat("Godeps/Godeps.json"); err == nil {
 		args = append([]string{"go"}, args...)

--- a/looper.go
+++ b/looper.go
@@ -45,11 +45,16 @@ out:
 func main() {
 	var tags string
 	var debug bool
+	var command string
 	flag.StringVar(&tags, "tags", "", "a list of build tags for testing.")
 	flag.BoolVar(&debug, "debug", false, "adds additional logging")
+	flag.StringVar(&command, "gotool", "go", "name of go command to run tests with (e.g., go, goapp")
 	flag.Parse()
 
-	runner := gat.Run{Tags: tags}
+	runner := gat.Run{
+		Tags:    tags,
+		Command: command,
+	}
 
 	Header()
 	if debug {


### PR DESCRIPTION
This adds support to use the goapp binary instead of the go binary to run the tests.  This can't be implemented with #26  although I support that initiative too.

More flags are frowned upon sometimes I know for sacrificing simplicity, but many of my projects use appengine classic which still requires the goapp tool to pull in appengine classic code (modified $GOROOT)
