### PR TITLE
Don't watch vendor directories. Follows #24

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -10,6 +10,9 @@ import (
 	"github.com/go-fsnotify/fsnotify"
 )
 
+// IgnoreVendor if using Go 1.5 vendor experiment
+var IgnoreVendor = (os.Getenv("GO15VENDOREXPERIMENT") == "1")
+
 type RecursiveWatcher struct {
 	*fsnotify.Watcher
 	Files   chan string
@@ -111,5 +114,6 @@ func Subfolders(path string) (paths []string) {
 // shouldIgnoreFile determines if a file should be ignored.
 // File names that begin with "." or "_" are ignored by the go tool.
 func shouldIgnoreFile(name string) bool {
-	return strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_")
+	isVendor := IgnoreVendor && name == "vendor"
+	return isVendor || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_")
 }


### PR DESCRIPTION
I think that it doesn't really make sense to watch vendor directories if they're excluded from tests anyway. Plus, when launched looper output all watched directories, and with many dependencies this can become quite annoying. 

I see from #24 that you wondered about making this change but didn't do it eventually. Do you have any reason for not watching directories that I'm not aware of?
