### PR TITLE
add timeout option to looper

### DIFF
--- a/looper.go
+++ b/looper.go
@@ -44,12 +44,14 @@ out:
 
 func main() {
 	var tags string
+	var timeout string
 	var debug bool
 	flag.StringVar(&tags, "tags", "", "a list of build tags for testing.")
+	flag.StringVar(&timeout, "timeout", "", "a duration to timeout a single test after")
 	flag.BoolVar(&debug, "debug", false, "adds additional logging")
 	flag.Parse()
 
-	runner := gat.Run{Tags: tags}
+	runner := gat.Run{Tags: tags, Timeout: timeout}
 
 	Header()
 	if debug {


### PR DESCRIPTION
I found it useful to have a timeout option. Ultimately the options for tags and timeout could be merged into a single flag, but for now this seems cleaner. If more options were added/requested it could be worth exploring though.

Thanks for all your work on this!